### PR TITLE
Allow variables to be extracted from LLM responses

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,17 +40,6 @@ export function extractMarkdownUrls(fullText: string): Set<string> {
   return urls;
 }
 
-// export function extractCodeBlocks(fullText: string): string[] {
-//   const codeBlocks: string[] = [];
-//   const tokens = marked.lexer(fullText);
-//   tokens.forEach(token => {
-//     if (token.type === 'code' && token.lang === 'graphql') {
-//       codeBlocks.push(token.text.trim());
-//     }
-//   });
-//   return codeBlocks;
-// }
-
 interface GraphQLBlock {
   query: string;
   variables?: string;
@@ -258,15 +247,6 @@ const isGraphiQLReachable = async () => {
     return false;
   }
 };
-
-// const openGraphiQLURLs = (codeBlocks: string[]) => {
-//   const baseUrl = 'http://localhost:3457/graphiql';
-//   for (const block of codeBlocks) {
-//     const encodedQuery = encodeURIComponent(block).replace(/%20/g, '+');
-//     const url = `${baseUrl}?query=${encodedQuery}`;
-//     vscode.env.openExternal(vscode.Uri.parse(url));
-//   }
-// };
 
 const openGraphiQLURLs = (codeBlocks: GraphQLBlock[]) => {
   const baseUrl = 'http://localhost:3457/graphiql';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,15 +40,42 @@ export function extractMarkdownUrls(fullText: string): Set<string> {
   return urls;
 }
 
-export function extractCodeBlocks(fullText: string): string[] {
-  const codeBlocks: string[] = [];
+// export function extractCodeBlocks(fullText: string): string[] {
+//   const codeBlocks: string[] = [];
+//   const tokens = marked.lexer(fullText);
+//   tokens.forEach(token => {
+//     if (token.type === 'code' && token.lang === 'graphql') {
+//       codeBlocks.push(token.text.trim());
+//     }
+//   });
+//   return codeBlocks;
+// }
+
+interface GraphQLBlock {
+  query: string;
+  variables?: string;
+}
+
+export function extractCodeBlocks(fullText: string): GraphQLBlock[] {
+  const blocks: GraphQLBlock[] = [];
   const tokens = marked.lexer(fullText);
+  let currentQuery: string | null = null;
+
   tokens.forEach(token => {
-    if (token.type === 'code' && token.lang === 'graphql') {
-      codeBlocks.push(token.text.trim());
+    if (token.type === 'code') {
+      if (token.lang === 'graphql') {
+        currentQuery = token.text.trim();
+      } else if (token.lang === 'json' && currentQuery) {
+        blocks.push({
+          query: currentQuery,
+          variables: token.text.trim()
+        });
+        currentQuery = null;
+      }
     }
   });
-  return codeBlocks;
+
+  return blocks;
 }
 
 async function isShopifyApp(): Promise<boolean> {
@@ -232,11 +259,26 @@ const isGraphiQLReachable = async () => {
   }
 };
 
-const openGraphiQLURLs = (codeBlocks: string[]) => {
+// const openGraphiQLURLs = (codeBlocks: string[]) => {
+//   const baseUrl = 'http://localhost:3457/graphiql';
+//   for (const block of codeBlocks) {
+//     const encodedQuery = encodeURIComponent(block).replace(/%20/g, '+');
+//     const url = `${baseUrl}?query=${encodedQuery}`;
+//     vscode.env.openExternal(vscode.Uri.parse(url));
+//   }
+// };
+
+const openGraphiQLURLs = (codeBlocks: GraphQLBlock[]) => {
   const baseUrl = 'http://localhost:3457/graphiql';
   for (const block of codeBlocks) {
-    const encodedQuery = encodeURIComponent(block).replace(/%20/g, '+');
-    const url = `${baseUrl}?query=${encodedQuery}`;
+    const encodedQuery = encodeURIComponent(block.query).replace(/%20/g, '+');
+    let url = `${baseUrl}?query=${encodedQuery}`;
+    
+    if (block.variables) {
+      const encodedVariables = encodeURIComponent(block.variables).replace(/%20/g, '+');
+      url += `&variables=${encodedVariables}`;
+    }
+    
     vscode.env.openExternal(vscode.Uri.parse(url));
   }
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,9 @@ export function extractCodeBlocks(fullText: string): GraphQLBlock[] {
   tokens.forEach(token => {
     if (token.type === 'code') {
       if (token.lang === 'graphql') {
+        if (currentQuery) {
+          blocks.push({ query: currentQuery });
+        }
         currentQuery = token.text.trim();
       } else if (token.lang === 'json' && currentQuery) {
         blocks.push({
@@ -63,6 +66,11 @@ export function extractCodeBlocks(fullText: string): GraphQLBlock[] {
       }
     }
   });
+
+  if (currentQuery) {
+    blocks.push({ query: currentQuery });
+    currentQuery = null;
+  }
 
   return blocks;
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -46,7 +46,7 @@ suite('Unit Test Suite', () => {
   });
 
   test('extractCodeBlocks handles GraphQL queries with variables', () => {
-    const testText = '```graphql\nquery { test }\n```\n```json\n{"var": "value"}\n```';
+    const testText = '```graphql\nquery { test }\n```\nSome text\n```json\n{"var": "value"}\n```';
     const blocks = extractCodeBlocks(testText);
 
     assert.strictEqual(blocks.length, 1);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -26,8 +26,8 @@ suite('Unit Test Suite', () => {
     const blocks = extractCodeBlocks(testText);
 
     assert.strictEqual(blocks.length, 2);
-    assert.strictEqual(blocks[0].trim(), 'query { test }');
-    assert.strictEqual(blocks[1].trim(), 'mutation { update }');
+    assert.strictEqual(blocks[0].query.trim(), 'query { test }');
+    assert.strictEqual(blocks[1].query.trim(), 'mutation { update }');
   });
 
   test('extractCodeBlocks ignores non-GraphQL blocks', () => {
@@ -35,7 +35,7 @@ suite('Unit Test Suite', () => {
     const blocks = extractCodeBlocks(testText);
 
     assert.strictEqual(blocks.length, 1);
-    assert.strictEqual(blocks[0].trim(), 'query { test }');
+    assert.strictEqual(blocks[0].query.trim(), 'query { test }');
   });
 
   test('extractMarkdownUrls ignores incomplete URLs during streaming', () => {
@@ -43,6 +43,15 @@ suite('Unit Test Suite', () => {
     const urls = extractMarkdownUrls(testText);
 
     assert.strictEqual(urls.size, 0, 'Should not include incomplete URLs');
+  });
+
+  test('extractCodeBlocks handles GraphQL queries with variables', () => {
+    const testText = '```graphql\nquery { test }\n```\n```json\n{"var": "value"}\n```';
+    const blocks = extractCodeBlocks(testText);
+
+    assert.strictEqual(blocks.length, 1);
+    assert.strictEqual(blocks[0].query.trim(), 'query { test }');
+    assert.strictEqual(blocks[0].variables?.trim(), '{"var": "value"}');
   });
 });
 
@@ -143,7 +152,10 @@ suite('Integration Test Suite', () => {
   });
 
   test('open-in-graphiql opens the correct URLs', async () => {
-    const codeBlocks = ['query { test }', 'mutation { update }'];
+    const codeBlocks = [
+      { query: 'query { test }' },
+      { query: 'mutation { update }' }
+    ];
 
     global.fetch = (async (input: Request | URL, init?: RequestInit) => {
       return {
@@ -157,7 +169,7 @@ suite('Integration Test Suite', () => {
 
     assert.strictEqual(openExternalStub.callCount, codeBlocks.length);
     for (let i = 0; i < codeBlocks.length; i++) {
-      const encodedQuery = encodeURIComponent(codeBlocks[i]).replace(/%20/g, '+');
+      const encodedQuery = encodeURIComponent(codeBlocks[i].query).replace(/%20/g, '+');
       const expectedUrl = `http://localhost:3457/graphiql?query=${encodedQuery}`;
       assert.ok(openExternalStub.getCall(i).calledWith(vscode.Uri.parse(expectedUrl)));
     }
@@ -213,7 +225,7 @@ suite('Integration Test Suite', () => {
   test('open-in-graphiql runs dev server when GraphiQL is not reachable', async function() {
     const clock = sandbox.useFakeTimers();
 
-    const codeBlocks = ['query { test }'];
+    const codeBlocks = [{ query: 'query { test }' }];
 
     let fetchCallCount = 0;
 


### PR DESCRIPTION
Implement the ability for the variables json to be passed in the URL when opening a mutation in graphiQL.

Example prompt: `@shopify help me create a new product for red shirts and when you give me the graphql mutation, give me the input variables seperately`

Response link: `http://localhost:3457/graphiql?query=mutation+CreateRedShirtProduct($input:+ProductInput!)+%7B%0A++productCreate(input:+$input)+%7B%0A++++product+%7B%0A++++++id%0A++++++title%0A++++++options+%7B%0A++++++++id%0A++++++++name%0A++++++++position%0A++++++++values%0A++++++++optionValues+%7B%0A++++++++++id%0A++++++++++name%0A++++++++++hasVariants%0A++++++++%7D%0A++++++%7D%0A++++++variants(first:+5)+%7B%0A++++++++nodes+%7B%0A++++++++++id%0A++++++++++title%0A++++++++++selectedOptions+%7B%0A++++++++++++name%0A++++++++++++value%0A++++++++++%7D%0A++++++++%7D%0A++++++%7D%0A++++%7D%0A++++userErrors+%7B%0A++++++field%0A++++++message%0A++++%7D%0A++%7D%0A%7D&variables=%7B%0A++%22input%22:+%7B%0A++++%22title%22:+%22Red+Shirt%22,%0A++++%22productOptions%22:+%5B%0A++++++%7B%0A++++++++%22name%22:+%22Color%22,%0A++++++++%22values%22:+%5B%0A++++++++++%7B%0A++++++++++++%22name%22:+%22Red%22%0A++++++++++%7D%0A++++++++%5D%0A++++++%7D%0A++++%5D%0A++%7D%0A%7D`